### PR TITLE
Hs 3212 2

### DIFF
--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -297,6 +297,10 @@ options = [
      dict(type=int,
           help="Set a max timeout for each feature (only if --fork)")),
 
+    (("--just-list",),
+     dict(action="store_true",
+          help="Do not run any test, just enumerate and print file paths")),
+
     # -- DISABLE-UNUSED-OPTION: Not used anywhere.
     # (("-S", "--strict"),
     # dict(action="store_true",

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -708,6 +708,12 @@ class ModelRunner(object):
             return False, feature
 
     def run_model(self, features=None):
+        if self.config.just_list:
+            for feature in self.features:
+                if feature.should_run(self.config):
+                    print(feature.filename)
+            return False
+
         # pylint: disable=too-many-branches
         if not self.context:
             self.context = Context(self)

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -162,6 +162,10 @@ class Context(object):
     # pylint: disable=too-many-instance-attributes
     FAIL_ON_CLEANUP_ERRORS = True
 
+    # compatibility with previous versions of behave
+    BEHAVE = ContextMode.BEHAVE
+    USER = ContextMode.USER
+
     def __init__(self, runner):
         self._runner = weakref.proxy(runner)
         self._config = runner.config


### PR DESCRIPTION
Added --just-list parameter to retrieve the list of tests after filtering tags.
Example: 
behave --tags ~skipci --tags ~racy --tags ~skip --tags common_channels

Will return the list of tests currently run by the CI.

It is important to explicity pass ~skip when using this parameter, because this tags is filtered by code in flu-sdk so behave is not aware of it if we don't pass it.
