### PR TITLE
Hs 3202

### DIFF
--- a/behave/reporter/junit.py
+++ b/behave/reporter/junit.py
@@ -88,7 +88,7 @@ if six.PY2:
     import traceback2 as traceback
 else:
     import traceback
-
+from behave.model_core import Status, StatusError
 
 def CDATA(text=None):   # pylint: disable=invalid-name
     # -- issue #70: remove_ansi_escapes(text)
@@ -429,6 +429,13 @@ class JUnitReporter(Reporter):
             else:
                 skip = ElementTree.Element(u'skipped')
                 case.append(skip)
+
+        if scenario.status_error == StatusError.none:
+            case.set(u"status_error", "none")
+        elif scenario.status_error == StatusError.timeout:
+            case.set(u"status_error", "timeout")
+        elif scenario.status_error == StatusError.crash:
+            case.set(u"status_error", "crash")
 
         # Create stdout section for each test case
         stdout = ElementTree.Element(u"system-out")

--- a/behave/reporter/junit.py
+++ b/behave/reporter/junit.py
@@ -70,6 +70,7 @@ Best sources are:
 # pylint: enable=line-too-long
 
 from __future__ import absolute_import
+import time
 import os.path
 import codecs
 from xml.etree import ElementTree
@@ -260,7 +261,8 @@ class JUnitReporter(Reporter):
 
         tree = ElementTreeWithCDATA(suite)
         report_dirname = self.config.junit_directory
-        report_basename = u'TESTS-%s.xml' % feature_filename
+        report_basename = u'TESTS-{}-{}.xml'.format(feature_filename,
+                                                    int(time.time()*1000000))
         report_filename = os.path.join(report_dirname, report_basename)
         tree.write(codecs.open(report_filename, "wb"), "UTF-8")
 

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -687,24 +687,25 @@ class ModelRunner(object):
                     else:
                         print("Child Process finished with exit code {}"
                               .format(proc.exitcode))
-                        error = Error.crash
+                        error = StatusError.crash
                 else:
                     print("killing Child Process after {} seconds timeout"
                           .format(timeout))
                     proc.terminate()
-                    error = Error.timeout
+                    error = StatusError.timeout
 
                 def setStatus(item, status):
                     if hasattr(item, "set_status") and callable(getattr(item,
                                                                 'set_status')):
-                        item.set_status(status)
+                        item.set_status(status[0])
+                        item.status_error = status[1]
                     else:
-                        item.status = status
+                        item.status = status[0]
+                        item.status_error = status[1]
 
                 self._forEachItemInFeatures(feature,
                                             setStatus,
-                                            Status.failed,
-                                            error)
+                                            [Status.failed, error])
                 return False, feature
         except KeyboardInterrupt:
             self.aborted = True


### PR DESCRIPTION
There are two minor changes here:
- Use timestamps in junit results filename, so we can store different results for the same tests.
- Fix a problem with the return value of the new error codes (timeout, crash)